### PR TITLE
Updates the types to include value inside of Genre

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,7 @@ export interface Error {
 }
 
 export interface Genre {
+	value: string;
 	albumCount: number;
 	songCount: number;
 }


### PR DESCRIPTION
Adds value in genre when sending a request to getGenres.

Possible JSON response:

```{
    "subsonic-response": {
        "status": "ok",
        "version": "1.16.1",
        "type": "navidrome",
        "serverVersion": "0.54.3 (734eb30a)",
        "openSubsonic": true,
        "genres": {
            "genre": [
                {
                    "value": "Rap",
                    "songCount": 2065,
                    "albumCount": 296
                },
                {
                    "value": "Hip-Hop",
                    "songCount": 1926,
                    "albumCount": 276
                }
            ]
        }
    }
}```