### PR TITLE
fix(jukeboxControl): allow passing multiple ids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -766,7 +766,7 @@ export default class SubsonicAPI {
 			| "set";
 		index?: number;
 		gain?: number;
-		id?: string;
+		id?: string | string[];
 		offset?: number;
 	}) {
 		return this.#requestJSON<


### PR DESCRIPTION
This PR fixes types for `jukeboxControl` to allow end users to pass multiple ids to `add` and `set` actions.