### PR TITLE
feat: expose buildUrl method

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,11 @@ customJSON<T>(method: string, params: Params): Promise<T>
 ```
 
 Allows you to make a custom request to the server and parse the response as JSON.
+
+### `buildUrl`
+
+```ts
+buildUrl(method: string, params: Record<string, unknown>) {
+```
+
+Builds a complete URL for a Subsonic API request with authentication and query parameters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,14 @@ export default class SubsonicAPI {
 		return base;
 	}
 
-	async #request(method: string, params?: Record<string, unknown>) {
+	/**
+ 	* Builds a complete URL for a Subsonic API request with authentication and query parameters.
+ 	*/
+	async buildUrl(method: string, params: Record<string, unknown>) {
+		return this.#buildUrl(method, params);
+	}
+
+	async #buildUrl(method: string, params?: Record<string, unknown>): Promise<URL> {
 		let base = this.baseURL();
 		if (!base.endsWith("rest/")) base += "rest/";
 
@@ -200,6 +207,12 @@ export default class SubsonicAPI {
 		} else {
 			throw new Error("no auth provided");
 		}
+
+		return url
+	}
+
+	async #request(method: string, params?: Record<string, unknown>) {
+		const url = await this.#buildUrl(method, params)
 
 		if (this.#config.post) {
 			const [path, search] = url.toString().split("?");


### PR DESCRIPTION
Hi there!
Thank you for your library, it's been a great help!
Often I find I don't need the API to perform an actual request, I just want a fully formed URL.
For instance, when using React Native, you might want to supply a coverArt URL to an Image component to handle, or a streamUrl to the player. In cases like this, you want to forward request handling to the native component and skip sending the request in JS.
I hope you find it useful.